### PR TITLE
feat: add widget empty notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ struct ProductView: View {
                 loadingSpinner.isHidden = true
             }
         }
+        // Widget unable to appear
+        .onReceive(NotificationCenter.default.publisher(for: .albyWidgetEmpty)) { _ in
+            loadingSpinner.isHidden = true
+        }
         // Thread ID change notification
         .onReceive(NotificationCenter.default.publisher(for: .albyThreadIdChanged)) { notification in
             if let newThreadId = notification.object as? String {
@@ -225,9 +229,24 @@ struct ProductView: View {
 }
 ```
 
+
+```swift
+// Inline widget example
+AlbyInlineWidgetView(
+    productId: "product-123",
+    widgetId: widgetId
+)
+.frame(height: 500)
+.padding(.horizontal)
+.onReceive(NotificationCenter.default.publisher(for: .albyWidgetEmpty)) { _ in
+    print("handle widget unable to load")
+}
+```
+
 ### Available Notifications
 
 - `.albyWidgetRendered`: Fired when the widget is fully loaded and ready to use
 - `.albyThreadIdChanged`: Fired when a conversation thread ID changes or is reset. The notification includes the new thread ID as its `object`, or `nil` when the conversation is reset.
+- `.albyWidgetEmpty`: Fired when the widget is unable to render. This can happen for a variety of reasons, for example, the product ID specified is not inside alby's product catalog.
 
 Both notifications are accessible through `NotificationCenter` after importing `AlbyWidget`.

--- a/Sources/AlbyWidget/AlbyWidget.swift
+++ b/Sources/AlbyWidget/AlbyWidget.swift
@@ -165,6 +165,10 @@ private struct AlbyWidgetView<Content: View>: View {
                         }
                         NotificationCenter.default.post(name: .albyWidgetRendered, object: nil)
                         break;
+                    case "widget-empty":
+                        widgetVisible = false
+                        NotificationCenter.default.post(name: .albyWidgetEmpty, object: nil)
+                        break;
                     case "preview-button-clicked":
                         self.sheetExpanded = true
                         bottomSheetPosition = .relativeTop(0.975)
@@ -293,4 +297,7 @@ extension Notification.Name {
     
     /// Notification sent when the Alby widget is rendered
     public static let albyWidgetRendered = Notification.Name("albyWidgetRendered")
+
+    /// Notification sent when the Alby widget is empty
+    public static let albyWidgetEmpty = Notification.Name("albyWidgetEmpty")
 }

--- a/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
+++ b/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
@@ -64,7 +64,13 @@ public struct AlbyInlineWidgetView: View {
       }
       .frame(minHeight: isLoading ? 200 : geometry.size.height)
       .onReceive(viewModel.callbackValueJS) { event in
-        if event == "widget-rendered" || event == "widget-empty" {
+        if event == "widget-rendered" {
+          NotificationCenter.default.post(name: .albyWidgetRendered, object: nil)
+          isLoading = false
+        }
+
+        if event == "widget-empty" {
+          NotificationCenter.default.post(name: .albyWidgetEmpty, object: nil)
           isLoading = false
         }
       }


### PR DESCRIPTION
- Introduced `.albyWidgetEmpty` notification for handling widget rendering failures.
- Updated README to document the new notification and its purpose.