### PR TITLE
fix: remove nested scrolling

### DIFF
--- a/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
+++ b/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
@@ -44,35 +44,36 @@ public struct AlbyInlineWidgetView: View {
 
   public var body: some View {
     let brandId = AlbySDK.shared.brandId ?? ""
-    
-    let urlString = "https://cdn.alby.com/assets/alby_widget.html?component=alby-generative-qa&brandId=\(brandId)&productId=\(productId)&widgetId=\(widgetId)\(threadId != nil ? "&threadId=\(threadId!)" : "")\(testId != nil ? "&testId=\(testId!)" : "")\(testVersion != nil ? "&testVersion=\(testVersion!)" : "")\(testDescription != nil ? "&testDescription=\(testDescription!)" : "")&autoScroll=true"
-    
-    GeometryReader { geometry in
-      ZStack {
-        SwiftWebView(
-          url: URL(string: urlString),
-          isScrollEnabled: true,
-          viewModel: viewModel)
-          .frame(height: geometry.size.height)
-        
-        if isLoading {
-          ProgressView()
-            .scaleEffect(1.5)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.white.opacity(0.8))
-        }
-      }
-      .frame(minHeight: isLoading ? 200 : geometry.size.height)
-      .onReceive(viewModel.callbackValueJS) { event in
-        if event == "widget-rendered" {
-          NotificationCenter.default.post(name: .albyWidgetRendered, object: nil)
-          isLoading = false
-        }
 
-        if event == "widget-empty" {
-          NotificationCenter.default.post(name: .albyWidgetEmpty, object: nil)
-          isLoading = false
-        }
+    let urlString = "https://cdn.alby.com/assets/alby_widget.html?component=alby-generative-qa&brandId=\(brandId)&productId=\(productId)&widgetId=\(widgetId)\(threadId != nil ? "&threadId=\(threadId!)" : "")\(testId != nil ? "&testId=\(testId!)" : "")\(testVersion != nil ? "&testVersion=\(testVersion!)" : "")\(testDescription != nil ? "&testDescription=\(testDescription!)" : "")&autoScroll=true"
+
+    ZStack {
+      // isScrollEnabled: false prevents the WebView from capturing scroll gestures
+      // when embedded inside a host app's ScrollView. Height grows dynamically via
+      // KVO on scrollView.contentSize so all content remains visible without internal scroll.
+      SwiftWebView(
+        url: URL(string: urlString),
+        isScrollEnabled: false,
+        viewModel: viewModel)
+        .frame(height: max(200, viewModel.contentHeight))
+
+      if isLoading {
+        ProgressView()
+          .scaleEffect(1.5)
+          .frame(maxWidth: .infinity)
+          .frame(height: 200)
+          .background(Color.white.opacity(0.8))
+      }
+    }
+    .onReceive(viewModel.callbackValueJS) { event in
+      if event == "widget-rendered" {
+        NotificationCenter.default.post(name: .albyWidgetRendered, object: nil)
+        isLoading = false
+      }
+
+      if event == "widget-empty" {
+        NotificationCenter.default.post(name: .albyWidgetEmpty, object: nil)
+        isLoading = false
       }
     }
   }

--- a/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
+++ b/Sources/AlbyWidget/View/AlbyInlineWidgetView.swift
@@ -48,9 +48,6 @@ public struct AlbyInlineWidgetView: View {
     let urlString = "https://cdn.alby.com/assets/alby_widget.html?component=alby-generative-qa&brandId=\(brandId)&productId=\(productId)&widgetId=\(widgetId)\(threadId != nil ? "&threadId=\(threadId!)" : "")\(testId != nil ? "&testId=\(testId!)" : "")\(testVersion != nil ? "&testVersion=\(testVersion!)" : "")\(testDescription != nil ? "&testDescription=\(testDescription!)" : "")&autoScroll=true"
 
     ZStack {
-      // isScrollEnabled: false prevents the WebView from capturing scroll gestures
-      // when embedded inside a host app's ScrollView. Height grows dynamically via
-      // KVO on scrollView.contentSize so all content remains visible without internal scroll.
       SwiftWebView(
         url: URL(string: urlString),
         isScrollEnabled: false,

--- a/Sources/AlbyWidget/View/SwiftWebView.swift
+++ b/Sources/AlbyWidget/View/SwiftWebView.swift
@@ -42,6 +42,7 @@ struct SwiftWebView: UIViewRepresentable, WebViewHandlerDelegate {
         webview.navigationDelegate = context.coordinator
         webview.allowsBackForwardNavigationGestures = false
         webview.scrollView.isScrollEnabled = isScrollEnabled
+        context.coordinator.observeContentSize(of: webview)
 
         if #available(iOS 16.4, *) {
             webview.isInspectable = true
@@ -53,6 +54,11 @@ struct SwiftWebView: UIViewRepresentable, WebViewHandlerDelegate {
         webview.backgroundColor = UIColor.white
 
         return webview
+    }
+
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        coordinator.contentSizeObservation?.invalidate()
+        coordinator.contentSizeObservation = nil
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
@@ -75,6 +81,7 @@ struct SwiftWebView: UIViewRepresentable, WebViewHandlerDelegate {
     class Coordinator: NSObject, WKNavigationDelegate {
         var parent: SwiftWebView
         var callbackValueFromNative: AnyCancellable?
+        var contentSizeObservation: NSKeyValueObservation?
 
         var delegate: WebViewHandlerDelegate?
 
@@ -83,7 +90,17 @@ struct SwiftWebView: UIViewRepresentable, WebViewHandlerDelegate {
             self.delegate = parent
         }
 
+        func observeContentSize(of webView: WKWebView) {
+            guard contentSizeObservation == nil else { return }
+            contentSizeObservation = webView.scrollView.observe(\.contentSize, options: [.new]) { [weak self] scrollView, _ in
+                DispatchQueue.main.async {
+                    self?.parent.viewModel.contentHeight = scrollView.contentSize.height
+                }
+            }
+        }
+
         deinit {
+            contentSizeObservation?.invalidate()
             callbackValueFromNative?.cancel()
         }
 

--- a/Sources/AlbyWidget/ViewModel/WebViewModel.swift
+++ b/Sources/AlbyWidget/ViewModel/WebViewModel.swift
@@ -7,4 +7,6 @@ class WebViewModel: ObservableObject {
 
     // Javascript to IOS
     var callbackValueJS = PassthroughSubject<String, Never>()
+
+    @Published var contentHeight: CGFloat = 0
 }


### PR DESCRIPTION
- isScrollEnabled: false
  - the WebView no longer competes for scroll gestures; the host app's ScrollView works normally
- Dynamic height via KVO on webView.scrollView.contentSize
  - as the AI streams its response, the widget frame grows to show all content, so no internal scroll is ever needed
- GeometryReader removed
  - it was forcing the WebView to fill all available space, which masked the problem